### PR TITLE
Add rewrite rule to reverse proxy configuration

### DIFF
--- a/docs/sources/installation/behind_proxy.md
+++ b/docs/sources/installation/behind_proxy.md
@@ -57,6 +57,9 @@ root_url = %(protocol)s://%(domain)s:/grafana
 ```
 
 #### Nginx configuration with sub path
+To make links to static assets work with Grafana running on a sub path
+an additional rewrite statement has to be included.
+
 ```
 server {
   listen 80;
@@ -65,6 +68,7 @@ server {
 
   location /grafana/ {
    proxy_pass http://localhost:3000/;
+   rewrite  ^/grafana/(.*)  /$1 break;
   }
 }
 ```


### PR DESCRIPTION
To make Grafana running on a sub path behind a reverse proxy being able to
resolve links to static assets an additional rewrite setting has to be introduced.
It basically strips the subpath off the URL. This means that for the Grafana server
it seems like there is no subpath.